### PR TITLE
Update peerDependencies for Angular version 12-13

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "test": "bash scripts/run-integration-test.sh"
   },
   "peerDependencies": {
-    "@angular/compiler": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@angular/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@angular/compiler": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   },
   "dependencies": {
     "@carbon/icon-helpers": "10.6.0"


### PR DESCRIPTION
Enable carbon-icons-angular to be utilized in Angular versions 12 & 13