### PR TITLE
Allow package to be used by modern Angular without npm install --force

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "test": "bash scripts/run-integration-test.sh"
   },
   "peerDependencies": {
-    "@angular/compiler": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@angular/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@angular/compiler": ">= 7.0.0 && < 16.0.0",
+    "@angular/core": ">= 7.0.0 && < 16.0.0"
   },
   "dependencies": {
     "@carbon/icon-helpers": "10.6.0"


### PR DESCRIPTION
Many Carbon components for Angular were created with very old versions of Angular. They work fine with the latest version but if someone wants to use them, they have to do an `npm install --force` because of the outdated peer dependencies.

This pull request allows carbon-icons-angular to be used by the latest Angular which is currently 15.2.1.